### PR TITLE
Fix /who displaying players on red team in blue list

### DIFF
--- a/src/org/opencraft/server/cmd/impl/StatusCommand.java
+++ b/src/org/opencraft/server/cmd/impl/StatusCommand.java
@@ -86,7 +86,7 @@ public class StatusCommand implements Command {
     player.getActionSender().sendChatMessage("- &d" + bluePlayers + " players on blue:");
     String bluemsg = "";
     for (Player other : names) {
-      if (other.team == 0) bluemsg += other.getName() + ", ";
+      if (other.team == 1) bluemsg += other.getName() + ", ";
     }
     if (!bluemsg.isEmpty()) player.getActionSender().sendChatMessage("- &c" + bluemsg);
 


### PR DESCRIPTION
Dunno if it was a typo or something but 0 seems to be the ID for team red and 1 seems to be the ID for team blue.