### PR TITLE
Fix flag dropping when player walks over spawn

### DIFF
--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -898,11 +898,6 @@ public class CTFGameMode extends GameMode {
         }
       }
     }
-    if (blockX == blockSpawnX && blockY == blockSpawnY && blockZ == blockSpawnZ) {
-      if (p.hasFlag) {
-        dropFlag(p.team);
-      }
-    }
     if (getMode() == Level.CTF && tournamentGameStarted) {
       for (Player t : World.getWorld().getPlayerList().getPlayers()) {
         Position op = t.getPosition();


### PR DESCRIPTION
This bug has been annoying me for a while now. I've known about it for a long time and have tested many hypotheses but none of which proved correct until now.

The issue was set in place for the classic days when spectators had their own spawns. Now that this is redundant, this code isn't really needed anymore.