### PR TITLE
Fix issue with duplicated player nickname in TAB

### DIFF
--- a/src/main/java/org/opencraft/server/model/PlayerUI.java
+++ b/src/main/java/org/opencraft/server/model/PlayerUI.java
@@ -219,8 +219,9 @@ public abstract class PlayerUI {
         String listName = p.getListName();
         if (!listName.equals(playerListName.get(p))){
           playerListName.put(p, listName);
+          short id = (p == this.player ? -1 : p.nameId);
           player.getActionSender().sendAddPlayerName(
-              p.nameId, p.getName(), p.getListName(), p.getTeamName(), (byte) 1);
+              id, p.getName(), p.getListName(), p.getTeamName(), (byte) 1);
         }
       }
     }

--- a/src/main/java/org/opencraft/server/net/ActionSender.java
+++ b/src/main/java/org/opencraft/server/net/ActionSender.java
@@ -229,7 +229,8 @@ public class ActionSender {
       boolean isSelf,
       boolean isVisible) {
     if (session.isExtensionSupported("ExtPlayerList", 2)) {
-      sendAddPlayerName(nameId, name, listName, teamName, (byte) 1);
+      short fixNameId = (nameId == session.getPlayer().nameId ? -1 : nameId);
+      sendAddPlayerName(fixNameId, name, listName, teamName, (byte) 1);
       if (!isSelf && isVisible) {
         sendExtSpawn(id, colorName, skinUrl != null ? skinUrl : name, x, y, z, rotation, look);
       }


### PR DESCRIPTION
This pull request fixes an issue players may experience using ClassiCube 1.3.(3/4?) client. ClassiCube 1.3.2 and earlier versions seem to be not affected.
![image](https://user-images.githubusercontent.com/35162137/207153209-cadb51f3-92d1-4e49-98cf-225ced6d259d.png)

UnknownShadow200 confirmed that they recently made changes to TAB behaviour so it became more accurate to classic.

