### PR TITLE
Big ol' batch of fixes

### DIFF
--- a/src/main/java/org/opencraft/server/cmd/impl/ActivateItemCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/ActivateItemCommand.java
@@ -42,6 +42,7 @@ import org.opencraft.server.cmd.CommandParameters;
 import org.opencraft.server.game.impl.GameSettings;
 import org.opencraft.server.model.Player;
 import org.opencraft.server.model.StoreItem;
+import org.opencraft.server.model.World;
 
 public class ActivateItemCommand implements Command {
   private StoreItem item = null;
@@ -59,6 +60,7 @@ public class ActivateItemCommand implements Command {
       player.getActionSender().sendChatMessage("- &eYou must join a team to do that!");
     else if (player.duelPlayer != null)
       player.getActionSender().sendChatMessage("- &eYou can't use the store while dueling!");
+    else if (!World.getWorld().getGameMode().tournamentGameStarted) player.getActionSender().sendChatMessage("- &eThe game has not started yet.");
     else {
       if (!(item.name.equals("Brush") && player.brush)) {
         boolean r = Server.getStore().buy(player, item.name);

--- a/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
@@ -65,6 +65,9 @@ public class CreeperCommand implements Command {
     int px = (pos.getX() - 16) / 32;
     int py = (pos.getY() - 16) / 32;
     int pz = ((pos.getZ() - 16) / 32);
+
+    player.creeperTime = System.currentTimeMillis();
+
     World.getWorld().broadcast("- " + player.parseName() + " &eisn't feeling so good...");
     World.getWorld().broadcast("- &esssssssSSSSSSSSS");
     ((CTFGameMode)World.getWorld()

--- a/src/main/java/org/opencraft/server/cmd/impl/IgnoreCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/IgnoreCommand.java
@@ -58,12 +58,26 @@ public class IgnoreCommand implements Command {
       String name = params.getStringArgument(0);
       Player p = Player.getPlayer(name, player.getActionSender());
 
+      // Custom behaviour for allowing players to toggle particles on/off
+      if (name.equals("-particles")) {
+        if (!player.ignorePlayers.contains(name)) {
+          player.ignorePlayers.add(name);
+          player.getActionSender().sendChatMessage("- &eNow ignoring TNT particles. Use this command again to stop.");
+        } else {
+          player.ignorePlayers.remove(name);
+          player.getActionSender().sendChatMessage("- &eParticles will now show when TNT explodes.");
+        }
+        return;
+      }
+
       if (p != null) {
         if (!p.isOp()) {
           player.ignore(p);
         } else {
           player.getActionSender().sendChatMessage("- &eYou cannot ignore an OP!");
         }
+      } else {
+          player.getActionSender().sendChatMessage("- &eCould not find player &b" + name + "&e.");
       }
     } else {
       player.getActionSender().sendChatMessage("Wrong number of arguments");

--- a/src/main/java/org/opencraft/server/cmd/impl/LineCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/LineCommand.java
@@ -61,6 +61,8 @@ public class LineCommand implements Command {
     Position pos = player.getPosition().toBlockPos();
     Rotation r = player.getRotation();
 
+    player.lineTime = System.currentTimeMillis();
+
     double heading =
         Math.toRadians((int) (Server.getUnsigned(r.getRotation()) * ((float) 360 / 256) - 90));
     double pitch =

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -693,7 +693,11 @@ public class CTFGameMode extends GameMode {
       if (p.team == 0) {
         blueFlagTaken = false;
         blueFlagDropped = true;
-        setBlueFlagPos(playerPos.getX(), playerPos.getZ() - 1, playerPos.getY());
+
+        // If the player is above the build ceiling, drop the flag at the build ceiling to prevent out of bounds issues
+        if (playerPos.getZ() > World.getWorld().getLevel().ceiling) setBlueFlagPos(playerPos.getX(), World.getWorld().getLevel().ceiling, playerPos.getY());
+        else setBlueFlagPos(playerPos.getX(), playerPos.getZ() - 1, playerPos.getY());
+
         blueFlagDroppedThread =
             new Thread(
                 new Runnable() {
@@ -716,7 +720,11 @@ public class CTFGameMode extends GameMode {
       } else {
         redFlagTaken = false;
         redFlagDropped = true;
-        setRedFlagPos(playerPos.getX(), playerPos.getZ() - 1, playerPos.getY());
+
+        // If the player is above the build ceiling, drop the flag at the build ceiling to prevent out of bounds issues
+        if (playerPos.getZ() > World.getWorld().getLevel().ceiling) setRedFlagPos(playerPos.getX(), World.getWorld().getLevel().ceiling, playerPos.getY());
+        else setRedFlagPos(playerPos.getX(), playerPos.getZ() - 1, playerPos.getY());
+
         redFlagDroppedThread =
             new Thread(
                 new Runnable() {

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -230,8 +230,10 @@ public class CTFGameMode extends GameMode {
       int ex = x  * 32 + 16;
       int ez = y  * 32 + 16;
       int ey = z  * 32 + 16;
-      player.getActionSender().sendSpawnEffect(Constants.EFFECT_TNT, ex, ey, ez, ex, ey, ez);
-      player.getActionSender().sendSpawnEffect(Constants.EFFECT_TNT_2, ex, ey, ez, ex, ey, ez);
+
+      // If the player does not want to see particles, don't show them
+      if (!player.ignorePlayers.contains("-particles")) player.getActionSender().sendSpawnEffect(Constants.EFFECT_TNT, ex, ey, ez, ex, ey, ez);
+      if (!player.ignorePlayers.contains("-particles")) player.getActionSender().sendSpawnEffect(Constants.EFFECT_TNT_2, ex, ey, ez, ex, ey, ez);
     }
   }
 

--- a/src/main/java/org/opencraft/server/io/LevelGzipper.java
+++ b/src/main/java/org/opencraft/server/io/LevelGzipper.java
@@ -59,7 +59,7 @@ public final class LevelGzipper {
   private ExecutorService service = Executors.newCachedThreadPool();
 
   private static final int[] DEFAULT_RESTRICTED_BLOCKS = new int[]{
-      7, 8, 10, Constants.HIT_RED, Constants.HIT_BLUE, Constants.LASER_RED, Constants.LASER_BLUE, 60};
+      7, 8, 9, 10, 11, Constants.HIT_RED, Constants.HIT_BLUE, Constants.LASER_RED, Constants.LASER_BLUE, 60 };
 
   public static LevelGzipper getLevelGzipper() {
     return INSTANCE;

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -97,7 +97,9 @@ public class Player extends Entity {
   public long flamethrowerTime = 0;
   public float flamethrowerFuel = Constants.FLAME_THROWER_FUEL;
   private boolean flamethrowerEnabled = false;
+  public long creeperTime;
   public long grenadeTime;
+  public long lineTime;
   public long rocketTime;
   public int headBlockType = 0;
   public Position headBlockPosition = null;

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -113,7 +113,7 @@ public class Player extends Entity {
   public boolean bountyMode = false;
   public int lastAmount = 0;
   public boolean bountyActive = false;
-  private HashSet<String> ignorePlayers = new HashSet<String>();
+  public HashSet<String> ignorePlayers = new HashSet<String>();
   private ActionSender actionSender = null;
   private Player instance;
   private Thread followThread;

--- a/src/main/java/org/opencraft/server/model/Store.java
+++ b/src/main/java/org/opencraft/server/model/Store.java
@@ -56,8 +56,10 @@ public class Store {
   public static final int linePrice = 25;
   public static final int creeperPrice = 40;
 
-  private static final int rocketRecharge = 10;
+  private static final int creeperRecharge = 7;
   private static final int grenadeRecharge = 7;
+  private static final int lineRecharge = 7;
+  private static final int rocketRecharge = 10;
 
   public Store() {
     addItem("BigTNT", new BigTNTItem("BigTNT", bigTNTPrice), "bigtnt");
@@ -89,10 +91,26 @@ public class Store {
       return false;
     }
 
+    if (itemname == "Creeper") {
+      long creeperCooldown = (System.currentTimeMillis() - p.creeperTime);
+      if (creeperCooldown < creeperRecharge * 1000) {
+        p.getActionSender().sendChatMessage("- &ePlease wait " + (creeperRecharge - creeperCooldown / 1000) + "" + " seconds");
+        return false;
+      }
+    }
+
     if (itemname == "Grenade") {
       long grenadeCooldown = (System.currentTimeMillis() - p.grenadeTime);
       if (grenadeCooldown < grenadeRecharge * 1000) {
         p.getActionSender().sendChatMessage("- &ePlease wait " + (grenadeRecharge - grenadeCooldown / 1000) + "" + " seconds");
+        return false;
+      }
+    }
+
+    if (itemname == "Line") {
+      long lineCooldown = (System.currentTimeMillis() - p.lineTime);
+      if (lineCooldown < lineRecharge * 1000) {
+        p.getActionSender().sendChatMessage("- &ePlease wait " + (lineRecharge - lineCooldown / 1000) + "" + " seconds");
         return false;
       }
     }


### PR DESCRIPTION
- Add `/ignore -particles` option for players to choose whether or not they wish to see exploding TNT particles.
- Fix flag not respawning when dropped above ceiling
- `/cr` and `/line` now have cooldowns of **7** seconds, matching grenades
- Disallow store before game starts
- Prevent being able to place still water/lava