### PR TITLE
Add API endpoints

### DIFF
--- a/src/main/java/org/opencraft/server/WebServer.java
+++ b/src/main/java/org/opencraft/server/WebServer.java
@@ -436,12 +436,10 @@ public class WebServer {
             respTextBuilder.append("  \"3\": null").append("\n");
           } else {
             for (int i = 0; i < 3; i++) {
-              System.out.println("kf size " + killFeed.size());
-              System.out.println("i " + i);
               if (i >= killFeed.size()) {
                 respTextBuilder.append("  \"" + i + "\": null");
               } else {
-                respTextBuilder.append("  \"" + i + "\": ").append(killFeed.get(i).getMessage());
+                respTextBuilder.append("  \"" + i + "\": ").append("\"" + killFeed.get(i).getMessage() + "\"");
               }
 
               if (i < 2) {

--- a/src/main/java/org/opencraft/server/WebServer.java
+++ b/src/main/java/org/opencraft/server/WebServer.java
@@ -380,10 +380,9 @@ public class WebServer {
               respTextBuilder.append("  \"error\": ").append("\"Player not found.\"").append("\n");
               respTextBuilder.append("}");
             } else {
-              // TODO: Once KDC monitoring has been implemented, use those values
-              int kills = 0;
-              int deaths = 0;
-              int captures = 0;
+              int kills = target.kills;
+              int deaths = target.deaths;
+              int captures = target.captures;
               int points = target.getPoints();
 
               respTextBuilder.append("  \"username\": ").append("\"" + username + "\"").append(",\n");

--- a/src/main/java/org/opencraft/server/WebServer.java
+++ b/src/main/java/org/opencraft/server/WebServer.java
@@ -312,7 +312,26 @@ public class WebServer {
           respTextBuilder.append("  \"map\": ").append("\"" + map + "\"").append(",\n");
           respTextBuilder.append("  \"timeRemaining\": ").append("\"" + timeRemaining + "\"").append(",\n");
           respTextBuilder.append("  \"redCaptures\": ").append(redCaptures).append(",\n");
-          respTextBuilder.append("  \"blueCaptures\": ").append(blueCaptures).append("\n");
+          respTextBuilder.append("  \"blueCaptures\": ").append(blueCaptures).append(",\n");
+
+          // Add red/blue players
+
+          Player[] names = World.getWorld().getPlayerList().getPlayers().toArray(new Player[0]);
+
+          List<Player> redTeam = new ArrayList<>();
+          List<Player> blueTeam = new ArrayList<>();
+
+          for (Player other : names) {
+            if (other.team == 0) redTeam.add(other);
+            if (other.team == 1) blueTeam.add(other);
+          }
+
+          String redPlayersJSON = getPlayersJSON(redTeam);
+          String bluePlayersJSON = getPlayersJSON(blueTeam);
+
+          respTextBuilder.append("  \"redPlayers\": [").append(redPlayersJSON).append("],\n");
+          respTextBuilder.append("  \"bluePlayers\": [").append(bluePlayersJSON).append("]\n");
+
           respTextBuilder.append("}");
 
           String respText = respTextBuilder.toString();
@@ -332,6 +351,15 @@ public class WebServer {
         exchange.close();
       }
     }
+
+    private String getPlayersJSON(List<Player> players) {
+      List<String> usernames = new ArrayList<>();
+      for (Player player : players) {
+        usernames.add("\"" + player.getName() + "\"");
+      }
+      return String.join(", ", usernames);
+    }
+
   }
 
   static class PlayerHandler implements HttpHandler {

--- a/src/main/java/org/opencraft/server/cmd/impl/StreamerModeCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/StreamerModeCommand.java
@@ -1,0 +1,66 @@
+/*
+ * Jacob_'s Capture the Flag for Minecraft Classic and ClassiCube
+ * Copyright (c) 2010-2014 Jacob Morgan
+ * Based on OpenCraft v0.2
+ *
+ * OpenCraft License
+ *
+ * Copyright (c) 2009 Graham Edgecombe, S�ren Enevoldsen and Brett Russell.
+ * All rights reserved.
+ *
+ * Distribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Distributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *     * Distributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the name of the OpenCraft nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.opencraft.server.cmd.impl;
+
+import org.opencraft.server.cmd.Command;
+import org.opencraft.server.cmd.CommandParameters;
+import org.opencraft.server.model.Player;
+import org.opencraft.server.model.World;
+
+public class StreamerModeCommand implements Command {
+
+  private static final StreamerModeCommand INSTANCE = new StreamerModeCommand();
+
+  /**
+   * Gets the singleton instance of this command.
+   *
+   * @return The singleton instance of this command.
+   */
+  public static StreamerModeCommand getCommand() {
+    return INSTANCE;
+  }
+
+  public void execute(Player player, CommandParameters params) {
+    player.streamerMode = !player.streamerMode;
+
+    if (player.streamerMode) {
+      player.getActionSender().sendChatMessage("- &eStreamer mode enabled.");
+    } else {
+      player.getActionSender().sendChatMessage("- &eStreamer mode disabled.");
+    }
+  }
+}

--- a/src/main/java/org/opencraft/server/game/GameMode.java
+++ b/src/main/java/org/opencraft/server/game/GameMode.java
@@ -81,7 +81,7 @@ public abstract class GameMode {
   public ArrayList<String> rtvNoPlayers = new ArrayList<>();
   public int rtvVotes = 0;
   public ArrayList<String> nominatedMaps = new ArrayList<>();
-  protected final ArrayList<KillFeedItem> killFeed = new ArrayList<>();
+  public final ArrayList<KillFeedItem> killFeed = new ArrayList<>();
   public String currentMap = null;
   public String previousMap = null;
   public Level map;

--- a/src/main/java/org/opencraft/server/game/GameMode.java
+++ b/src/main/java/org/opencraft/server/game/GameMode.java
@@ -155,6 +155,7 @@ public abstract class GameMode {
     registerCommand("stats", StatsCommand.getCommand());
     registerCommand("status", StatusCommand.getCommand());
     registerCommand("store", StoreCommand.getCommand());
+    registerCommand("streamermode", StreamerModeCommand.getCommand());
     registerCommand("team", TeamCommand.getCommand());
     registerCommand("tp", TeleportCommand.getCommand());
     registerCommand("unban", UnbanCommand.getCommand());

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -76,8 +76,8 @@ public class CTFGameMode extends GameMode {
   public boolean blueFlagDropped = false;
   public Thread redFlagDroppedThread;
   public Thread blueFlagDroppedThread;
-  public int redCaptures;
-  public int blueCaptures;
+  public static int redCaptures;
+  public static int blueCaptures;
   public boolean redFlagTaken = false;
   public boolean blueFlagTaken = false;
 
@@ -1319,7 +1319,7 @@ public class CTFGameMode extends GameMode {
     return new CTFPlayerUI(this, p);
   }
 
-  public int getMode() {
+  public static int getMode() {
     return World.getWorld().getLevel().mode;
   }
 }

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -39,6 +39,7 @@ package org.opencraft.server.game.impl;
 import org.opencraft.server.Configuration;
 import org.opencraft.server.Constants;
 import org.opencraft.server.Server;
+import org.opencraft.server.WebServer;
 import org.opencraft.server.cmd.impl.DefuseCommand;
 import org.opencraft.server.cmd.impl.DefuseTNTCommand;
 import org.opencraft.server.cmd.impl.FlagDropCommand;
@@ -484,6 +485,8 @@ public class CTFGameMode extends GameMode {
         sendKillFeed(p);
       }
     }
+
+    WebServer.killFeed = killFeed;
   }
 
   private void openSpawns() {

--- a/src/main/java/org/opencraft/server/game/impl/CTFPlayerUI.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFPlayerUI.java
@@ -24,6 +24,10 @@ public class CTFPlayerUI extends PlayerUI {
 
   @Override
   protected String getStatus0() {
+    if (player.streamerMode) {
+      return "";
+    }
+
     String redFlag = ctf.redFlagTaken ? " &6[!]" : "";
     String blueFlag = ctf.blueFlagTaken ? " &6[!]" : "";
     return "Map: "
@@ -47,6 +51,10 @@ public class CTFPlayerUI extends PlayerUI {
 
   @Override
   protected String getStatus2() {
+    if (player.streamerMode) {
+      return "";
+    }
+
     if(hasTimer()) {
       return getFlamethrowerMessage();
     } else {
@@ -61,6 +69,7 @@ public class CTFPlayerUI extends PlayerUI {
   private String getTimerMessage() {
     String timerSetting = null;
     String timerMessage = null;
+
     if (ctf.getMode() == Level.TDM) {
       timerSetting = "TDMTimeLimit";
       timerMessage = "Team Deathmatch";
@@ -78,6 +87,14 @@ public class CTFPlayerUI extends PlayerUI {
     } else if (!World.getWorld().getGameMode().tournamentGameStarted) {
       remaining = GameSettings.getInt(timerSetting) * 60;
     }
+
+    // If streamer mode is enabled, minimize the HUD
+    if (player.streamerMode) {
+      String redFlag = ctf.redFlagTaken ? " &6[!]" : "";
+      String blueFlag = ctf.blueFlagTaken ? " &6[!]" : "";
+      return "&c" + ctf.redCaptures + redFlag + " &9" + ctf.blueCaptures + blueFlag + " &f" + prettyTime((int) remaining);
+    }
+
     return timerMessage + " | " + prettyTime((int) remaining);
   }
 

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -128,6 +128,7 @@ public class Player extends Entity {
   private final PlayerUI ui;
   public Position safePosition = new Position(0, 0, 0);
   private int currentRoundPoints = Constants.INITIAL_PLAYER_POINTS;
+  public boolean streamerMode = false;
 
   // CTF
   public final LinkedList<Mine> mines = new LinkedList<Mine>();

--- a/src/main/java/org/opencraft/server/model/PlayerUI.java
+++ b/src/main/java/org/opencraft/server/model/PlayerUI.java
@@ -172,7 +172,7 @@ public abstract class PlayerUI {
     return builder.toString();
   }
 
-  protected static String prettyTime(int seconds) {
+  public static String prettyTime(int seconds) {
     int ms = (int) Math.floor(seconds / 60 % 60);
     int sr = (int) Math.floor(seconds / 1 % 60);
     String mm, ss;


### PR DESCRIPTION
This commit adds three new API endpoints to the web server. This API was built for a stream overlay software I am working on, but has other applications as well for future developers.

`/api/game/` - shows information about the game such as score, time remaining and players on teams.
`/api/player?p=[username goes here]` - shows information regarding player performance in the current game (kills, caps, deaths etc.)
`/api/kills` - shows information regarding the in-game kill feed.

I have also introduced the `/streamermode` command for players to toggle between the default and a minimalized version of the HUD. 