### PR TITLE
Make sure strings are properly encoded

### DIFF
--- a/src/main/java/org/opencraft/server/net/codec/MinecraftProtocolEncoder.java
+++ b/src/main/java/org/opencraft/server/net/codec/MinecraftProtocolEncoder.java
@@ -84,10 +84,13 @@ public final class MinecraftProtocolEncoder extends ProtocolEncoderAdapter {
           break;
         case STRING:
           String str = packet.getStringField(field.getName());
-          ByteBuffer bytes = Charset.forName("Cp437").encode(str);
-          buf.put(bytes);
-          for (int i = str.length(); i < 64; i++) {
-            buf.put((byte) 0x20);
+          byte[] bytes = str.getBytes("Cp437");
+          for (int i = 0; i < 64; i++) {
+            if (i >= bytes.length) {
+              buf.put((byte) 0x20);
+            } else {
+              buf.put(bytes[i]);
+            }
           }
           break;
       }


### PR DESCRIPTION
The current string encoding implementation is not reliable enough because:
A) The length is not limited;
B) `str.length()` might not be equal to the actual count of bytes sent to the client if `str` contains non-ASCII characters.

This is probably not critical since DiscordBot correctly handles special characters received from Discord users, but I think it's still worth fixing the issue.