### PR TITLE
Creeper item buff

### DIFF
--- a/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
@@ -57,6 +57,7 @@ public class CreeperCommand implements Command {
 
   public void execute(Player player, CommandParameters params) {
     player.creeperTime = System.currentTimeMillis();
+    player.isCreepering = true;
 
     World w = World.getWorld();
     w.broadcast("- " + player.parseName() + " &eisn't feeling so good...");

--- a/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
@@ -60,27 +60,45 @@ public class CreeperCommand implements Command {
   }
 
   public void execute(Player player, CommandParameters params) {
-    Thread creeperThread;
-    creeperThread = new Thread(
-      () -> {
-        player.creeperTime = System.currentTimeMillis();
+    player.creeperTime = System.currentTimeMillis();
+    float creeperTimeSetting = GameSettings.getFloat("CreeperTime");
 
-        World w = World.getWorld();
-        w.broadcast("- " + player.parseName() + " &eisn't feeling so good...");
-        w.broadcast("- &esssssssSSSSSSSSS");
+    World w = World.getWorld();
+    w.broadcast("- " + player.parseName() + " &eisn't feeling so good...");
+    w.broadcast("- &esssssssSSSSSSSSS");
 
-        try {
-          Thread.sleep((long)(1000 * GameSettings.getFloat("CreeperTime")));
-        } catch (InterruptedException ex) {}
+    if (creeperTimeSetting > 0.0f) {
+      Thread creeperThread;
+      creeperThread = new Thread(
+        () -> {
+          try {
+            Thread.sleep((long)(1000 * GameSettings.getFloat("CreeperTime")));
+          } catch (InterruptedException ex) {}
 
-        int radius = GameSettings.getInt("CreeperRadius");
-	Position pos = player.getPosition().toBlockPos();
-        ((CTFGameMode)w.getGameMode()).explodeTNT(
-	  player, w.getLevel(), pos.getX(), pos.getY(), pos.getZ(), radius, LETHAL, TEAMKILL, false, NAME
-	);
+          int radius = GameSettings.getInt("CreeperRadius");
+          if (radius < 0) {
+            radius = 0;
+          }
+
+          Position pos = player.getPosition().toBlockPos();
+          World w_ = World.getWorld();
+          ((CTFGameMode)w.getGameMode()).explodeTNT(
+            player, w_.getLevel(), pos.getX(), pos.getY(), pos.getZ(), radius, LETHAL, TEAMKILL, false, NAME
+          );
+        }
+      );
+
+      creeperThread.start();
+    } else {
+      int radius = GameSettings.getInt("CreeperRadius");
+      if (radius < 0) {
+        radius = 0;
       }
-    );
-    
-    creeperThread.start();
+
+      Position pos = player.getPosition().toBlockPos();
+      ((CTFGameMode)w.getGameMode()).explodeTNT(
+        player, w.getLevel(), pos.getX(), pos.getY(), pos.getZ(), radius, LETHAL, TEAMKILL, false, NAME
+      );
+    }
   }
 }

--- a/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
@@ -46,8 +46,6 @@ import org.opencraft.server.model.World;
 
 public class CreeperCommand implements Command {
   private static final CreeperCommand INSTANCE = new CreeperCommand();
-  private static final int DELAY = 2000;
-  private static final int RADIUS = 4;
   private static final boolean LETHAL = true;
   private static final boolean TEAMKILL = true;
   private static final String NAME = "Creeper";
@@ -72,20 +70,14 @@ public class CreeperCommand implements Command {
         w.broadcast("- &esssssssSSSSSSSSS");
 
         try {
-          Thread.sleep(DELAY);
+          Thread.sleep((long)(1000 * GameSettings.getFloat("CreeperTime")));
         } catch (InterruptedException ex) {}
 
-        Position pos = player.getPosition();
-        int px = pos.getX();
-        int py = pos.getY();
-        int pz = pos.getZ();
-
-        px = (px - 16) / 32;
-        py = (py - 16) / 32;
-        pz = (pz - 16) / 32;
-
-        CTFGameMode gm = (CTFGameMode)w.getGameMode();
-        gm.explodeTNT(player, w.getLevel(), px, py, pz, RADIUS, LETHAL, TEAMKILL, false, NAME);
+        int radius = GameSettings.getInt("CreeperRadius");
+	Position pos = player.getPosition().toBlockPos();
+        ((CTFGameMode)w.getGameMode()).explodeTNT(
+	  player, w.getLevel(), pos.getX(), pos.getY(), pos.getZ(), radius, LETHAL, TEAMKILL, false, NAME
+	);
       }
     );
     

--- a/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/CreeperCommand.java
@@ -46,6 +46,11 @@ import org.opencraft.server.model.World;
 
 public class CreeperCommand implements Command {
   private static final CreeperCommand INSTANCE = new CreeperCommand();
+  private static final int DELAY = 2000;
+  private static final int RADIUS = 4;
+  private static final boolean LETHAL = true;
+  private static final boolean TEAMKILL = true;
+  private static final String NAME = "Creeper";
 
   /**
    * Gets the singleton instance of this command.
@@ -57,21 +62,33 @@ public class CreeperCommand implements Command {
   }
 
   public void execute(Player player, CommandParameters params) {
-    if (GameSettings.getBoolean("Tournament")) {
-      player.getActionSender().sendChatMessage("- &e/cr is disabled during the tournament.");
-      return;
-    }
-    Position pos = player.getPosition();
-    int px = (pos.getX() - 16) / 32;
-    int py = (pos.getY() - 16) / 32;
-    int pz = ((pos.getZ() - 16) / 32);
+    Thread creeperThread;
+    creeperThread = new Thread(
+      () -> {
+        player.creeperTime = System.currentTimeMillis();
 
-    player.creeperTime = System.currentTimeMillis();
+        World w = World.getWorld();
+        w.broadcast("- " + player.parseName() + " &eisn't feeling so good...");
+        w.broadcast("- &esssssssSSSSSSSSS");
 
-    World.getWorld().broadcast("- " + player.parseName() + " &eisn't feeling so good...");
-    World.getWorld().broadcast("- &esssssssSSSSSSSSS");
-    ((CTFGameMode)World.getWorld()
-        .getGameMode())
-        .explodeTNT(player, World.getWorld().getLevel(), px, py, pz, 4, true, true, false, null);
+        try {
+          Thread.sleep(DELAY);
+        } catch (InterruptedException ex) {}
+
+        Position pos = player.getPosition();
+        int px = pos.getX();
+        int py = pos.getY();
+        int pz = pos.getZ();
+
+        px = (px - 16) / 32;
+        py = (py - 16) / 32;
+        pz = (pz - 16) / 32;
+
+        CTFGameMode gm = (CTFGameMode)w.getGameMode();
+        gm.explodeTNT(player, w.getLevel(), px, py, pz, RADIUS, LETHAL, TEAMKILL, false, NAME);
+      }
+    );
+    
+    creeperThread.start();
   }
 }

--- a/src/main/java/org/opencraft/server/game/GameMode.java
+++ b/src/main/java/org/opencraft/server/game/GameMode.java
@@ -359,6 +359,7 @@ public abstract class GameMode {
                 player.team = -1;
                 player.hasVoted = false;
                 player.hasNominated = false;
+		player.isCreepering = false;
                 player.currentRoundPointsEarned = 0;
                 player.setPoints(GameSettings.getInt("InitialPoints"));
                 player.kills = 0;

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -605,6 +605,7 @@ public class CTFGameMode extends GameMode {
                 player.team = -1;
                 player.hasFlag = false;
                 player.hasTNT = false;
+		player.isCreepering = false;
                 player.kills = 0;
                 player.deaths = 0;
                 player.captures = 0;

--- a/src/main/java/org/opencraft/server/game/impl/GameSettings.java
+++ b/src/main/java/org/opencraft/server/game/impl/GameSettings.java
@@ -42,7 +42,7 @@ public class GameSettings {
     add("CreeperPrice", TYPE_INT, 30);
     add("CreeperRadius", TYPE_INT, 4);
     add("CreeperTime", TYPE_FLOAT, 2.0f);
-    add("CreeperShield", TYPE_BOOLEAN, true);
+    add("CreeperShield", TYPE_BOOLEAN, false);
     add("GrenadePrice", TYPE_INT, 35);
     add("LinePrice", TYPE_INT, 25);
     add("RocketPrice", TYPE_INT, 60);

--- a/src/main/java/org/opencraft/server/game/impl/GameSettings.java
+++ b/src/main/java/org/opencraft/server/game/impl/GameSettings.java
@@ -39,7 +39,10 @@ public class GameSettings {
     add("BigTNTPrice", TYPE_INT, 70);
     add("BigTNTAmount", TYPE_INT, 7);
     add("BigTNTRadius", TYPE_INT, 3);
-    add("CreeperPrice", TYPE_INT, 40);
+    add("CreeperPrice", TYPE_INT, 30);
+    add("CreeperRadius", TYPE_INT, 4);
+    add("CreeperTime", TYPE_FLOAT, 2.0f);
+    add("CreeperShield", TYPE_BOOLEAN, true);
     add("GrenadePrice", TYPE_INT, 35);
     add("LinePrice", TYPE_INT, 25);
     add("RocketPrice", TYPE_INT, 60);

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -1085,10 +1085,13 @@ public class Player extends Entity implements IPlayer {
   }
 
   public boolean isSafe() {
-    final long CREEPER_TIME = 2000;
     long curTime = System.currentTimeMillis();
+    boolean creeperShield = GameSettings.getBoolean("CreeperShield");
 
     return curTime - safeTime < Constants.SAFE_TIME
-      || curTime - creeperTime < CREEPER_TIME;
+      || (
+        GameSettings.getBoolean("CreeperShield")
+          && (curTime - creeperTime < (long)(1000 * GameSettings.getFloat("CreeperTime")))
+      );
   }
 }

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -1085,6 +1085,10 @@ public class Player extends Entity implements IPlayer {
   }
 
   public boolean isSafe() {
-    return System.currentTimeMillis() - safeTime < Constants.SAFE_TIME;
+    final long CREEPER_TIME = 2000;
+    long curTime = System.currentTimeMillis();
+
+    return curTime - safeTime < Constants.SAFE_TIME
+      || curTime - creeperTime < CREEPER_TIME;
   }
 }

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -158,6 +158,7 @@ public class Player extends Entity implements IPlayer {
   public boolean hasNominated = false;
   // STORE STUFF
   public int bigTNTRemaining = 0;
+  public boolean isCreepering = false;
 
   // Laser Tag
   private int ammo;
@@ -482,6 +483,7 @@ public class Player extends Entity implements IPlayer {
 
   public void died(Player attacker) {
     deaths++;
+    this.isCreepering = false;
     if (killstreak >= 10) {
       World.getWorld()
           .broadcast(
@@ -620,6 +622,7 @@ public class Player extends Entity implements IPlayer {
           .sendChatMessage(
               "- &aThis map was contributed by: " + World.getWorld().getLevel().getCreator());
     }
+    this.isCreepering = false;
     if (isHidden && !team.equals("spec")) {
       Server.log(getName() + " is now unhidden");
       makeVisible();

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -1086,7 +1086,6 @@ public class Player extends Entity implements IPlayer {
 
   public boolean isSafe() {
     long curTime = System.currentTimeMillis();
-    boolean creeperShield = GameSettings.getBoolean("CreeperShield");
 
     return curTime - safeTime < Constants.SAFE_TIME
       || (

--- a/src/main/java/org/opencraft/server/model/Store.java
+++ b/src/main/java/org/opencraft/server/model/Store.java
@@ -104,6 +104,10 @@ public class Store {
         p.getActionSender().sendChatMessage("- &ePlease wait " + (creeperRecharge - creeperCooldown / 1000) + "" + " seconds");
         return false;
       }
+      if (p.isCreepering) {
+        p.getActionSender().sendChatMessage("- &eYou need to explode before using this again!");
+        return false;
+      }
     }
 
     if (itemname == "Grenade") {

--- a/src/main/java/org/opencraft/server/task/impl/CreeperTask.java
+++ b/src/main/java/org/opencraft/server/task/impl/CreeperTask.java
@@ -34,34 +34,61 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package org.opencraft.server.cmd.impl;
+package org.opencraft.server.task.impl;
 
-import org.opencraft.server.cmd.Command;
-import org.opencraft.server.cmd.CommandParameters;
+import org.opencraft.server.game.impl.CTFGameMode;
+import org.opencraft.server.game.impl.GameSettings;
 import org.opencraft.server.model.Player;
+import org.opencraft.server.model.Position;
+import org.opencraft.server.model.Level;
 import org.opencraft.server.model.World;
-import org.opencraft.server.task.TaskQueue;
-import org.opencraft.server.task.impl.CreeperTask;
+import org.opencraft.server.task.ScheduledTask;
 
-public class CreeperCommand implements Command {
-  private static final CreeperCommand INSTANCE = new CreeperCommand();
+/* Does the delayed explosion for creeper item. */
+public class CreeperTask extends ScheduledTask {
+  private static final boolean LETHAL = true;
+  private static final boolean TEAMKILL = true;
+  private static final String NAME = "Creeper";
 
-  /**
-   * Gets the singleton instance of this command.
-   *
-   * @return The singleton instance of this command.
-   */
-  public static CreeperCommand getCommand() {
-    return INSTANCE;
+  private CTFGameMode ctf;
+  private Player invoker;
+  private int pastDeaths;
+  private Level level;
+
+  public CreeperTask(Player invoker, Level level) {
+    super(0);
+
+    this.ctf = (CTFGameMode)World.getWorld().getGameMode();
+    this.invoker = invoker;
+    this.pastDeaths = invoker.deaths;
+    this.level = level;
+
+    float creeperTime = GameSettings.getFloat("CreeperTime");
+    if (creeperTime > 0.0f) {
+      this.setDelay((long)(1000 * creeperTime));
+    }
   }
 
-  public void execute(Player player, CommandParameters params) {
-    player.creeperTime = System.currentTimeMillis();
+  public void execute() {
+    // Do not explode if the player died.
+    if (pastDeaths == invoker.deaths) {
+      doCreeper();
+    }
+  }
 
-    World w = World.getWorld();
-    w.broadcast("- " + player.parseName() + " &eisn't feeling so good...");
-    w.broadcast("- &esssssssSSSSSSSSS");
+  private void doCreeper() {
+    int radius = GameSettings.getInt("CreeperRadius");
+    if (radius < 0) {
+      radius = 0;
+    }
 
-    TaskQueue.getTaskQueue().schedule(new CreeperTask(player, w.getLevel()));
+    Position pos = this.invoker.getPosition().toBlockPos();
+
+    ctf.explodeTNT(
+      this.invoker, this.level, pos.getX(), pos.getY(), pos.getZ(),
+      radius, LETHAL, TEAMKILL, false, NAME
+    );
+
+    this.stop();
   }
 }

--- a/src/main/java/org/opencraft/server/task/impl/CreeperTask.java
+++ b/src/main/java/org/opencraft/server/task/impl/CreeperTask.java
@@ -52,7 +52,6 @@ public class CreeperTask extends ScheduledTask {
 
   private CTFGameMode ctf;
   private Player invoker;
-  private int pastDeaths;
   private Level level;
 
   public CreeperTask(Player invoker, Level level) {
@@ -60,7 +59,6 @@ public class CreeperTask extends ScheduledTask {
 
     this.ctf = (CTFGameMode)World.getWorld().getGameMode();
     this.invoker = invoker;
-    this.pastDeaths = invoker.deaths;
     this.level = level;
 
     float creeperTime = GameSettings.getFloat("CreeperTime");
@@ -70,10 +68,21 @@ public class CreeperTask extends ScheduledTask {
   }
 
   public void execute() {
-    // Do not explode if the player died.
-    if (pastDeaths == invoker.deaths) {
+    /* Only explode if:
+     * - the player hasn't died
+     * - the player hasn't changed teams
+     * - the player hasn't rejoined his own team
+     * - the game hasn't ended
+     * - a new game hasn't started
+     * - the player's session hasn't been unregistered */
+    if (
+      invoker.isCreepering
+        && invoker.getSession().getPlayer() != null
+    ) {
       doCreeper();
     }
+
+    this.stop();
   }
 
   private void doCreeper() {
@@ -89,6 +98,6 @@ public class CreeperTask extends ScheduledTask {
       radius, LETHAL, TEAMKILL, false, NAME
     );
 
-    this.stop();
+    invoker.isCreepering = false;
   }
 }


### PR DESCRIPTION
Buff the creeper store item by:
* reducing cost to 30 points
* adding 2 second delay and invincibility timer
* adding CreeperRadius, CreeperTime, and CreeperShield settings
* fixing creeper blast zone position to be centered at the block the player's head is occupying.