### PR TITLE
Stalemate + smoke zone tweaks

### DIFF
--- a/src/main/java/org/opencraft/server/cmd/impl/FlagDropCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/FlagDropCommand.java
@@ -39,6 +39,7 @@ package org.opencraft.server.cmd.impl;
 import org.opencraft.server.cmd.Command;
 import org.opencraft.server.cmd.CommandParameters;
 import org.opencraft.server.game.impl.CTFGameMode;
+import org.opencraft.server.game.impl.GameSettings;
 import org.opencraft.server.model.Player;
 import org.opencraft.server.model.World;
 
@@ -56,6 +57,11 @@ public class FlagDropCommand implements Command {
   }
 
   public void execute(Player player, CommandParameters params) {
+    if (!GameSettings.getBoolean("FlagDrops")) {
+      player.getActionSender().sendChatMessage("Flag dropping is disabled.");
+      return;
+    }
+
     // Check if player using command is on a team
     if (player.team != -1) {
       if (player.hasFlag) {

--- a/src/main/java/org/opencraft/server/cmd/impl/SmokeGrenadeCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/SmokeGrenadeCommand.java
@@ -41,6 +41,7 @@ import org.opencraft.server.Server;
 import org.opencraft.server.cmd.Command;
 import org.opencraft.server.cmd.CommandParameters;
 import org.opencraft.server.game.impl.CTFGameMode;
+import org.opencraft.server.game.impl.GameSettings;
 import org.opencraft.server.model.*;
 
 public class SmokeGrenadeCommand implements Command {
@@ -109,19 +110,20 @@ public class SmokeGrenadeCommand implements Command {
                 if (block != 0 && block != BlockConstants.CLOTH_DARKGRAY && block != Constants.BLOCK_INVISIBLE) {
                     int zones = World.getWorld().getNumberOfSmokeZones();
                     int id = zones + 1;
-                    int radius = 8;
+                    int radius = GameSettings.getInt("SmokeGrenadeRadius");
+                    int delay = GameSettings.getInt("SmokeGrenadeDelay");
                     final SmokeZone zone = new SmokeZone(bx - radius, by - radius, bz, bx + radius, by + radius, bz + radius, id);
 
                     try {
                         World.getWorld().addSmokeZone(zone);
                         zone.updateDensity(255);
-                        Thread.sleep(2000);
+                        Thread.sleep(delay);
                         zone.updateDensity(191);
-                        Thread.sleep(2000);
+                        Thread.sleep(delay);
                         zone.updateDensity(127);
-                        Thread.sleep(2000);
+                        Thread.sleep(delay);
                         zone.updateDensity(64);
-                        Thread.sleep(2000);
+                        Thread.sleep(delay);
                         World.getWorld().removeSmokeZone(zone);
                     } catch (InterruptedException ex) {
                         World.getWorld().removeSmokeZone(zone);

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -715,12 +715,15 @@ public class CTFGameMode extends GameMode {
   }
 
   public void checkForStalemate() {
+    if (redFlagTaken && blueFlagTaken) {
+      antiStalemateStartTime = System.currentTimeMillis();
+    }
+
     if ((suddenDeath || GameSettings.getBoolean("AntiStalemate"))
         && redFlagTaken && blueFlagTaken) {
       World.getWorld().broadcast("- &eAnti-stalemate mode activated!");
       World.getWorld().broadcast("- &eIf your teammate gets tagged you'll drop the flag");
       antiStalemate = true;
-      antiStalemateStartTime = System.currentTimeMillis();
     }
   }
 
@@ -1489,7 +1492,7 @@ public class CTFGameMode extends GameMode {
   public void step() {
     super.step();
 
-    if (antiStalemate) {
+    if (redFlagTaken && blueFlagTaken) {
       long stalemateElapsedTime = System.currentTimeMillis() - antiStalemateStartTime;
 
       // If 90 seconds have passed, end the stalemate by making everyone drop the flag
@@ -1500,7 +1503,6 @@ public class CTFGameMode extends GameMode {
           }
         }
 
-        antiStalemate = false;
         minuteBroadcasted = false;
         thirtySecBroadcasted = false;
         tenSecBroadcasted = false;

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -73,7 +73,13 @@ public class CTFGameMode extends GameMode {
   public boolean blueFlagTaken = false;
 
   private boolean antiStalemate;
+  private long antiStalemateStartTime;
   private boolean suddenDeath;
+
+  // TODO: Fix millisecond shenanigans in game loop so we don't need these variables
+  private boolean minuteBroadcasted = false;
+  private boolean thirtySecBroadcasted = false;
+  private boolean tenSecBroadcasted = false;
 
   public CTFGameMode() {
     super();
@@ -714,6 +720,7 @@ public class CTFGameMode extends GameMode {
       World.getWorld().broadcast("- &eAnti-stalemate mode activated!");
       World.getWorld().broadcast("- &eIf your teammate gets tagged you'll drop the flag");
       antiStalemate = true;
+      antiStalemateStartTime = System.currentTimeMillis();
     }
   }
 
@@ -835,6 +842,9 @@ public class CTFGameMode extends GameMode {
       }
     }
     antiStalemate = false;
+    minuteBroadcasted = false;
+    thirtySecBroadcasted = false;
+    tenSecBroadcasted = false;
   }
 
   public void dropFlag(Player p) {
@@ -1478,10 +1488,42 @@ public class CTFGameMode extends GameMode {
   @Override
   public void step() {
     super.step();
+
+    if (antiStalemate) {
+      long stalemateElapsedTime = System.currentTimeMillis() - antiStalemateStartTime;
+
+      // If 90 seconds have passed, end the stalemate by making everyone drop the flag
+      if (stalemateElapsedTime > 1.5 * 60 * 1000) {
+        for (Player p : World.getWorld().getPlayerList().getPlayers()) {
+          if (p.hasFlag) {
+            ((CTFGameMode) World.getWorld().getGameMode()).dropFlag(p, true, false);
+          }
+        }
+
+        antiStalemate = false;
+        minuteBroadcasted = false;
+        thirtySecBroadcasted = false;
+        tenSecBroadcasted = false;
+      } else {
+        // Show messages at 60s, 30s, and 10s remaining
+        if (!minuteBroadcasted && stalemateElapsedTime > 30 * 1000 && stalemateElapsedTime < 31 * 1000) {
+          World.getWorld().broadcast("- &e1 minute remaining until the stalemate ends!");
+          minuteBroadcasted = true;
+        } else if (!thirtySecBroadcasted && stalemateElapsedTime > 60 * 1000 && stalemateElapsedTime < 61 * 1000) {
+          World.getWorld().broadcast("- &e30 seconds remaining until the stalemate ends!");
+          thirtySecBroadcasted = true;
+        } else if (!tenSecBroadcasted && stalemateElapsedTime > 80 * 1000 && stalemateElapsedTime < 81 * 1000) {
+          World.getWorld().broadcast("- &e10 seconds remaining until the stalemate ends!");
+          tenSecBroadcasted = true;
+        }
+      }
+    }
+
     String setting = getMode() == Level.TDM ? "TDMTimeLimit" : "TimeLimit";
     int timeLimit = GameSettings.getInt(setting);
     if (timeLimit > 0) {
       long elapsedTime = System.currentTimeMillis() - gameStartTime;
+
       if (elapsedTime > timeLimit * 60 * 1000 && !suddenDeath) {
         if (getMode() == Level.CTF && redCaptures == blueCaptures) {
             World.getWorld().broadcast("- &eSudden death mode activated!");

--- a/src/main/java/org/opencraft/server/game/impl/GameSettings.java
+++ b/src/main/java/org/opencraft/server/game/impl/GameSettings.java
@@ -45,6 +45,8 @@ public class GameSettings {
     add("LinePrice", TYPE_INT, 25);
     add("RocketPrice", TYPE_INT, 60);
     add("SmokeGrenadePrice", TYPE_INT, 50);
+    add("SmokeGrenadeRadius", TYPE_INT, 8);
+    add("SmokeGrenadeDelay", TYPE_INT, 2000);
     add("RocketSpeed", TYPE_INT, 25);
   }
 

--- a/src/main/java/org/opencraft/server/game/impl/GameSettings.java
+++ b/src/main/java/org/opencraft/server/game/impl/GameSettings.java
@@ -22,6 +22,7 @@ public class GameSettings {
     add("OnlyTDM", TYPE_BOOLEAN, false);
     add("Debug", TYPE_BOOLEAN, false);
     add("Tournament", TYPE_BOOLEAN, false);
+    add("FlagDrops", TYPE_BOOLEAN, false);
     add("FlameThrowerStartDistanceFromPlayer", TYPE_INT, 3);
     add("FlameThrowerLength", TYPE_INT, 2);
     add("FlameThrowerRechargeTime", TYPE_INT, 30);

--- a/src/main/java/org/opencraft/server/model/SmokeZone.java
+++ b/src/main/java/org/opencraft/server/model/SmokeZone.java
@@ -59,20 +59,40 @@ public class SmokeZone {
 
       this.density = density;
 
-      player.getSession().getActionSender().sendSelectionCuboid(
-              this.id,
-              "SmokeZone" + this.id,
-              (short) minX,
-              (short) minZ,
-              (short) minY,
-              (short) maxX,
-              (short) maxZ,
-              (short) maxY,
-              (short) 36,
-              (short) 36,
-              (short) 36,
-              (short) density
-      );
+      if (player.team == -1) {
+        // Increase visibility for spectators, but also show that there is a smoke zone
+        player.getSession().getActionSender().sendSelectionCuboid(
+                this.id,
+                "SmokeZone" + this.id,
+                (short) minX,
+                (short) minZ,
+                (short) minY,
+                (short) maxX,
+                (short) maxZ,
+                (short) maxY,
+                (short) 36,
+                (short) 36,
+                (short) 36,
+                (short) 40
+        );
+      }
+
+      else {
+        player.getSession().getActionSender().sendSelectionCuboid(
+                this.id,
+                "SmokeZone" + this.id,
+                (short) minX,
+                (short) minZ,
+                (short) minY,
+                (short) maxX,
+                (short) maxZ,
+                (short) maxY,
+                (short) 36,
+                (short) 36,
+                (short) 36,
+                (short) density
+        );
+      }
     }
   }
 

--- a/src/main/java/org/opencraft/server/net/packet/handler/impl/MovementPacketHandler.java
+++ b/src/main/java/org/opencraft/server/net/packet/handler/impl/MovementPacketHandler.java
@@ -98,17 +98,19 @@ public class MovementPacketHandler implements PacketHandler<MinecraftSession> {
       if ((x / 32 >= minX && x / 32 <= maxX)
               && (z / 32 >= minZ && z / 32 <= maxZ)
               && (y / 32 >= minY && y / 32 <= maxY)) {
-                short fogDensity = 0;
-                if (zone.density == 255) fogDensity = 1;
-                if (zone.density == 191) fogDensity = 7;
-                if (zone.density == 127) fogDensity = 14;
-                if (zone.density == 64) fogDensity = 28;
+        if (player.team != -1) {
+          short fogDensity = 0;
+          if (zone.density == 255) fogDensity = 1;
+          if (zone.density == 191) fogDensity = 7;
+          if (zone.density == 127) fogDensity = 14;
+          if (zone.density == 64) fogDensity = 28;
 
-                player.getActionSender().sendMapProperty(4, fogDensity);
-                player.getActionSender().sendMapColor(2, (short)34, (short)34, (short)34);
-                player.isInSmokeZone = true;
+          player.getActionSender().sendMapProperty(4, fogDensity);
+          player.getActionSender().sendMapColor(2, (short) 34, (short) 34, (short) 34);
+          player.isInSmokeZone = true;
+        }
       } else {
-        if (player.isInSmokeZone) {
+        if (player.isInSmokeZone && player.team != -1) {
           player.getActionSender().sendMapProperty(4, World.getWorld().getLevel().viewDistance);
           player.getActionSender().sendMapColor(2, Constants.DEFAULT_COLORS[2][0], Constants.DEFAULT_COLORS[2][1], Constants.DEFAULT_COLORS[2][2]);
 


### PR DESCRIPTION
- Made it so flags automatically reset when in stalemate mode for 90 seconds, with messages warning players that it will happen.
- Added a new `FlagDrops` setting to control whether players can pass flags. Note: Doing /fd affects stalemate timer.
- Added `SmokeGrenadeRadius` and `SmokeGrenadeDelay` for customization of smoke zones.
- Made it so spectators are not affected by smoke zones, but can still see a more transparent version to signify that it is still there.