### PR TITLE
Gameplay balances

### DIFF
--- a/src/main/java/org/opencraft/server/Constants.java
+++ b/src/main/java/org/opencraft/server/Constants.java
@@ -173,8 +173,6 @@ public final class Constants {
 
   public static final String[] MAP_EXTENSIONS = new String[] {"dat", "lvl", "cw"};
 
-  public static final int ICE_MELT_TIME = 60000;
-
   /** The protocol version of Minecraft that this version of OpenCraft is compatible with. */
   public static final int PROTOCOL_VERSION = 7;
 

--- a/src/main/java/org/opencraft/server/cmd/impl/FuelCommand.java
+++ b/src/main/java/org/opencraft/server/cmd/impl/FuelCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Jacob_'s Capture the Flag for Minecraft Classic and ClassiCube
+ * Copyright (c) 2010-2014 Jacob Morgan
+ * Based on OpenCraft v0.2
+ *
+ * OpenCraft License
+ *
+ * Copyright (c) 2009 Graham Edgecombe, S�ren Enevoldsen and Brett Russell.
+ * All rights reserved.
+ *
+ * Distribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Distributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *     * Distributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the name of the OpenCraft nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.opencraft.server.cmd.impl;
+
+import org.opencraft.server.Constants;
+import org.opencraft.server.cmd.Command;
+import org.opencraft.server.cmd.CommandParameters;
+import org.opencraft.server.model.Player;
+
+public class FuelCommand implements Command {
+  private static final FuelCommand INSTANCE = new FuelCommand();
+
+  /**
+   * Gets the singleton instance of this command.
+   *
+   * @return The singleton instance of this command.
+   */
+  public static FuelCommand getCommand() {
+    return INSTANCE;
+  }
+
+  public void execute(final Player player, CommandParameters params) {
+    player.flamethrowerFuel = Constants.FLAME_THROWER_FUEL; // Refill the flamethrower
+  }
+}

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -1429,6 +1429,24 @@ public class CTFGameMode extends GameMode {
           player.getActionSender().sendChatMessage("- &bPlace a purple block to explode TNT.");
         }
 
+        if (player.hasTNT){
+          player.lagTNTs++;
+          player.lastTNTTime = System.currentTimeMillis();
+
+          if (player.lagTNTs == 3) {
+            player
+                .getActionSender()
+                .sendChatMessage(
+                    "- &cWARNING: You will be kicked automatically"
+                        + " if you continue to spam TNTs.");
+          } else if (player.lagTNTs == 7) {
+            player.getActionSender().sendLoginFailure("\"TNT spam\" is not allowed");
+            player.getSession().close();
+          }
+          player.getActionSender().sendBlock(x, y, z, (short) 0x00);
+          return;
+        }
+
         // Red player places blue TNT
         if (player.team == 0 && type == Constants.BLOCK_TNT_BLUE) {
           player.getActionSender().sendChatMessage("- &eYou are not allowed to place blue TNT!");

--- a/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
+++ b/src/main/java/org/opencraft/server/game/impl/CTFGameMode.java
@@ -1516,6 +1516,30 @@ public class CTFGameMode extends GameMode {
           && !blueFlagTaken
           && !ignore) {
         player.getActionSender().sendBlock(x, y, z, (short) Constants.BLOCK_BLUE_FLAG);
+      } else if (type == Constants.BLOCK_VINE) {
+        // Prevent vine bridging by checking if all surrounding blocks are air
+
+        // Get surrounding block types
+        int blockBelow = level.getBlock(x, y, z - 1);
+        int blockRight = level.getBlock(x + 1, y, z);
+        int blockLeft = level.getBlock(x - 1, y, z);
+        int blockFront = level.getBlock(x, y + 1, z);
+        int blockBack = level.getBlock(x, y - 1, z);
+
+        if (blockBelow == 0) {
+          if ((blockRight == 0 || blockRight == Constants.BLOCK_VINE) &&
+              (blockLeft == 0 || blockLeft == Constants.BLOCK_VINE) &&
+              (blockFront == 0 || blockFront == Constants.BLOCK_VINE) &&
+              (blockBack == 0 || blockBack == Constants.BLOCK_VINE)) {
+            player.getActionSender().sendBlock(x, y, z, (short) 0x00);
+          } else {
+            player.getActionSender().sendBlock(x, y, z, (short) Constants.BLOCK_VINE);
+            level.setBlock(x, y, z, type);
+          }
+        } else {
+          player.getActionSender().sendBlock(x, y, z, (short) Constants.BLOCK_VINE);
+          level.setBlock(x, y, z, type);
+        }
       } else if (type > -1) {
         if (!ignore) {
           level.setBlock(x, y, z, (mode == 1 ? type : 0));

--- a/src/main/java/org/opencraft/server/game/impl/GameSettings.java
+++ b/src/main/java/org/opencraft/server/game/impl/GameSettings.java
@@ -26,7 +26,8 @@ public class GameSettings {
     add("FlameThrowerStartDistanceFromPlayer", TYPE_INT, 3);
     add("FlameThrowerLength", TYPE_INT, 2);
     add("FlameThrowerRechargeTime", TYPE_INT, 30);
-    add("FlameThrowerDuration", TYPE_INT, 8);
+    add("FlameThrowerDuration", TYPE_INT, 10);
+    add("AutoRechargeFlamethrower", TYPE_BOOLEAN, false);
     add("Ammo", TYPE_INT, 20); // number of shots before reloading
     add("Health", TYPE_INT, 24); // number of hits taken before having to resupply
     add("ReloadStep", TYPE_INT, 3);
@@ -47,8 +48,9 @@ public class GameSettings {
     add("CreeperTime", TYPE_FLOAT, 2.0f);
     add("CreeperShield", TYPE_BOOLEAN, false);
     add("GrenadePrice", TYPE_INT, 35);
-    add("LinePrice", TYPE_INT, 25);
+    add("LinePrice", TYPE_INT, 15);
     add("RocketPrice", TYPE_INT, 60);
+    add("FlameThrowerFuelPrice", TYPE_INT, 10);
     add("SmokeGrenadePrice", TYPE_INT, 50);
     add("SmokeGrenadeRadius", TYPE_INT, 8);
     add("SmokeGrenadeDelay", TYPE_INT, 2000);

--- a/src/main/java/org/opencraft/server/game/impl/GameSettings.java
+++ b/src/main/java/org/opencraft/server/game/impl/GameSettings.java
@@ -53,6 +53,8 @@ public class GameSettings {
     add("SmokeGrenadeRadius", TYPE_INT, 8);
     add("SmokeGrenadeDelay", TYPE_INT, 2000);
     add("RocketSpeed", TYPE_INT, 25);
+    add("IceMeltTime", TYPE_INT, 60000);
+    add("VineDecayTime", TYPE_INT, 30000);
   }
 
   public static Object get(String k) {

--- a/src/main/java/org/opencraft/server/model/CustomBlockDefinition.java
+++ b/src/main/java/org/opencraft/server/model/CustomBlockDefinition.java
@@ -280,7 +280,7 @@ public class CustomBlockDefinition {
       Constants.BLOCK_VINE,
       "Vine",
       Constants.BLOCK_SOLIDITY_SWIM_THROUGH,
-      128,
+      96,
       506,
       506,
       506,

--- a/src/main/java/org/opencraft/server/model/Level.java
+++ b/src/main/java/org/opencraft/server/model/Level.java
@@ -152,6 +152,7 @@ public final class Level implements Cloneable {
   private final Queue<Position> updateQueue = new ArrayDeque<>();
 
   private final Queue<UpdateBlock> iceBlocks = new LinkedList<>();
+  private final Queue<UpdateBlock> vineBlocks = new LinkedList<>();
 
   /** Generates a level. */
   public Level() {
@@ -954,9 +955,23 @@ public final class Level implements Cloneable {
     synchronized (iceBlocks) {
       while (!iceBlocks.isEmpty()) {
         UpdateBlock block = iceBlocks.peek();
-        if (System.currentTimeMillis() - block.time > Constants.ICE_MELT_TIME) {
+        if (System.currentTimeMillis() - block.time > GameSettings.getInt("IceMeltTime")) {
           iceBlocks.remove();
           if (getBlock(block.position) == 60) {
+            setBlock(block.position, 0);
+          }
+        } else {
+          break;
+        }
+      }
+    }
+
+    synchronized (vineBlocks) {
+      while (!vineBlocks.isEmpty()) {
+        UpdateBlock block = vineBlocks.peek();
+        if (System.currentTimeMillis() - block.time > GameSettings.getInt("VineDecayTime")) {
+          vineBlocks.remove();
+          if (getBlock(block.position) == Constants.BLOCK_VINE) {
             setBlock(block.position, 0);
           }
         } else {
@@ -1104,6 +1119,12 @@ public final class Level implements Cloneable {
     synchronized (iceBlocks) {
       if (type == 60) {
         iceBlocks.add(new UpdateBlock(position, System.currentTimeMillis()));
+      }
+    }
+
+    synchronized (vineBlocks) {
+      if (type == Constants.BLOCK_VINE) {
+        vineBlocks.add(new UpdateBlock(position, System.currentTimeMillis()));
       }
     }
   }

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -1037,16 +1037,19 @@ public class Player extends Entity implements IPlayer {
       }
     } else {
       if (flamethrowerFuel != (float) Constants.FLAME_THROWER_FUEL) {
-        int chargeTime = GameSettings.getInt("FlameThrowerRechargeTime");
-        float rechargeRate = (float) Constants.FLAME_THROWER_FUEL / chargeTime;
-        long time = System.currentTimeMillis();
-        long dt = time - flamethrowerTime;
-        // Recharge rate in seconds, dt in milliseconds
-        flamethrowerFuel += rechargeRate * dt / 1000;
-        flamethrowerTime = time;
-        if (flamethrowerFuel >= Constants.FLAME_THROWER_FUEL) {
-          flamethrowerFuel = Constants.FLAME_THROWER_FUEL;
-          getActionSender().sendChatMessage("- &eFlame thrower charged.");
+        if (GameSettings.getBoolean("AutoRechargeFlamethrower")) {
+          int chargeTime = GameSettings.getInt("FlameThrowerRechargeTime");
+          float rechargeRate = (float) Constants.FLAME_THROWER_FUEL / chargeTime;
+          long time = System.currentTimeMillis();
+          long dt = time - flamethrowerTime;
+          // Recharge rate in seconds, dt in milliseconds
+          flamethrowerFuel += rechargeRate * dt / 1000;
+          flamethrowerTime = time;
+
+          if (flamethrowerFuel >= Constants.FLAME_THROWER_FUEL) {
+            flamethrowerFuel = Constants.FLAME_THROWER_FUEL;
+            getActionSender().sendChatMessage("- &eFlame thrower charged.");
+          }
         }
       }
     }

--- a/src/main/java/org/opencraft/server/model/Player.java
+++ b/src/main/java/org/opencraft/server/model/Player.java
@@ -80,6 +80,7 @@ public class Player extends Entity implements IPlayer {
   public String partialChatMessage = "";
   public String lastMessage;
   public String announcement = "";
+  public long lastTNTTime;
   public long lastMessageTime;
   public long lastPacketTime;
   public int heldBlock = 0;
@@ -91,6 +92,7 @@ public class Player extends Entity implements IPlayer {
   public long moveTime = 0;
   public int team = -1;
   public int outOfBoundsBlockChanges = 0;
+  public int lagTNTs = 0;
   public int placeBlock = -1;
   public boolean placeSolid = false;
   public boolean isHidden = false;
@@ -1004,6 +1006,12 @@ public class Player extends Entity implements IPlayer {
         getActionSender().sendLoginFailure("You were auto-kicked for being AFK for 60+ minutes.");
         getSession().close();
       }
+    }
+
+    // Reset lag TNT checker
+    if (lastTNTTime > 0 && System.currentTimeMillis() - lastTNTTime >= 5000) {
+      lagTNTs = 0;
+      lastTNTTime = 0;
     }
 
     World.getWorld().getGameMode().processPlayerMove(this);

--- a/src/main/java/org/opencraft/server/model/Store.java
+++ b/src/main/java/org/opencraft/server/model/Store.java
@@ -38,6 +38,7 @@ package org.opencraft.server.model;
 
 import org.opencraft.server.cmd.impl.ActivateItemCommand;
 import org.opencraft.server.cmd.impl.CreeperCommand;
+import org.opencraft.server.cmd.impl.FuelCommand;
 import org.opencraft.server.cmd.impl.GrenadeCommand;
 import org.opencraft.server.cmd.impl.LineCommand;
 import org.opencraft.server.cmd.impl.RocketCommand;
@@ -57,6 +58,7 @@ public class Store {
   public static int linePrice = GameSettings.getInt("LinePrice");
   public static int creeperPrice = GameSettings.getInt("CreeperPrice");
   public static int smokeGrenadePrice = GameSettings.getInt("SmokeGrenadePrice");
+  public static int flamethrowerFuelPrice = GameSettings.getInt("FlameThrowerFuelPrice");
 
   private static final int creeperRecharge = 7;
   private static final int grenadeRecharge = 7;
@@ -84,6 +86,10 @@ public class Store {
         "SmokeGrenade",
         new SimpleItem("SmokeGrenade", smokeGrenadePrice, "Fogs an area temporarily", SmokeGrenadeCommand.getCommand()),
         "sg");
+    addItem(
+        "FlameThrowerFuel",
+        new SimpleItem("FlameThrowerFuel", flamethrowerFuelPrice, "Buys fuel to power the flamethrower", FuelCommand.getCommand()),
+        "ff");
   }
 
   public boolean buy(Player p, String itemname) {
@@ -134,7 +140,7 @@ public class Store {
       }
     }
 
-    if (itemname == "SmokeGrenade") {
+    if (itemname == "FlameThrowerFuel") {
       long smokeGrenadeCooldown = (System.currentTimeMillis() - p.smokeGrenadeTime);
       if (smokeGrenadeCooldown < smokeGrenadeRecharge * 1000) {
         p.getActionSender().sendChatMessage("- &ePlease wait " + (smokeGrenadeRecharge - smokeGrenadeCooldown / 1000) + "" + " seconds");
@@ -177,6 +183,9 @@ public class Store {
     } else if (name == "SmokeGrenade") {
       item = new SimpleItem("SmokeGrenade", price, "Fogs an area temporarily", SmokeGrenadeCommand.getCommand());
       command = "sg";
+    } else if (name == "FlameThrowerFuel") {
+      item = new SimpleItem("FlameThrowerFuel", price, "Buys fuel to power the flamethrower", FuelCommand.getCommand());
+      command = "ff";
     }
 
     items.put(name, item);


### PR DESCRIPTION
- Flamethrower recharge has been removed. Players may buy an entire bar of fuel for 10 points using /ff.
- Flamethrower now lasts a total of 10 seconds instead of 8.
- Vines are now 1/4 slower.
- Vines now decay after 30 seconds.
- Vines must now be placed either on the ground, on top of another vine, or near a wall to prevent vine bridging.
- Lines now cost 15 points instead of 25 to compensate vine bridging nerf.